### PR TITLE
patch sur les fuites de mémoire de ConvexShape

### DIFF
--- a/include/BBOP/Graphics/EBO.h
+++ b/include/BBOP/Graphics/EBO.h
@@ -11,6 +11,9 @@ public:
 	GLuint ID;
 	// Constructor that generates a Elements Buffer Object and links it to indices
 	EBO(GLuint* indices, GLsizeiptr size);
+  EBO();
+
+  void init(GLuint* indices, GLsizeiptr size);
 
 	// Binds the EBO
 	void Bind() const;

--- a/include/BBOP/Graphics/VBO.h
+++ b/include/BBOP/Graphics/VBO.h
@@ -12,6 +12,9 @@ public:
 	GLuint ID;
 	// Constructor that generates a Vertex Buffer Object and links it to vertices
 	VBO(GLfloat* vertices, GLsizeiptr size, GLenum typeVBO);
+  VBO();
+
+  void init(GLfloat* vertices, GLsizeiptr size, GLenum typeVBO);
 
 	// Binds the VBO
 	void Bind() const;

--- a/include/BBOP/Graphics/shapeClass.h
+++ b/include/BBOP/Graphics/shapeClass.h
@@ -17,7 +17,8 @@ class Shape : public BbopDrawable
 public:
   Shape(GLfloat* vertices, GLsizeiptr verticesSize, GLuint* indices, GLsizeiptr indicesSize);
   Shape();
-  
+
+  void init(GLfloat* vertices, GLsizeiptr verticesSize, GLuint* indices, GLsizeiptr indicesSize);
   virtual void buildVAO() = 0;
   virtual void updateVBO() = 0;
   virtual void updateVBORGB() = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -18,23 +18,11 @@ int main() {
   cout << "creation de la scene" << endl;
   Scene defaultScene(1.0f,Vector3i(255,255,255));
   //creation d'un rectangle a afficher, par default blanc en haut a gauche de l'image
-  cout << "creation du rectangle" << endl;
-  RectangleShape defaultRect;
-  defaultRect.setSize(Vector2f(100.0f,100.0f));
-  defaultRect.setOrigin(Vector2f(50.0f,50.0f));
-  defaultRect.setColor(Vector3i(15,182,245));
-  defaultRect.setAlpha(0.5f);
+  
+  Vector2f list[8] = {Vector2f(0.0f,0.0f), Vector2f(124.0f,56.0f), Vector2f(32.0f,125.0f), Vector2f(52.0f,250.0f),Vector2f(0.0f,0.0f), Vector2f(124.0f,56.0f), Vector2f(32.0f,125.0f), Vector2f(52.0f,250.0f)};
+  ConvexShape defaultConvex(8,list);
 
-  cout << "creation du sprite" << endl;
-  Sprite defaultSprite(Texture("imgTesting/mario.png"));
-  defaultSprite.setAlpha(0.5f);
-  defaultSprite.setPosition(Vector2f(150.0f,150.0f));
-  defaultSprite.setSize(Vector2f(100.0f,100.0f));
-  //defaultSprite.setRGBFilterState(true);
-  int width,height;
-  glfwGetWindowSize(window, &width, &height);
-  cout << width << ";" << height << endl;
-   // Main while loop
+  // Main while loop
 	while (!glfwWindowShouldClose(window))
 	{
     bbopCleanWindow(window, Vector3i(0,0,0),1.0);
@@ -43,25 +31,8 @@ int main() {
     ///code zone
     //////////////////////////////////////////////////////////////
     
-    //test des collision entre sprite et rectangle par default
-    if(defaultSprite.getCollisionBox()->check(defaultRect.getCollisionBox()))
-      cout << "hit" << glfwGetTime() << endl;
-    //utilisation de la scene par default
     defaultScene.Use();
-    //affichage du rectangle  avec sa rotation
-    defaultRect.setRotation(defaultRect.getRotation()+0.1);
-    defaultScene.Draw(defaultRect);
-    //affichage du sprite mario, texture par default si non trouvé
-    defaultScene.Draw(defaultSprite);
-     //gestiond des mouvement de mario
-    if(glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS)
-      defaultSprite.move(Vector2f(0.0f,-5.0f));
-    if(glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS)
-      defaultSprite.move(Vector2f(0.0f,5.0f));
-    if(glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS)
-      defaultSprite.move(Vector2f(5.0f,0.0f));   
-    if(glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS)
-      defaultSprite.move(Vector2f(-5.0f,0.0f));
+    defaultScene.Draw(defaultConvex);
 
     //////////////////////////////////////////////////////////////
     

--- a/src/BBOP/Graphics/EBO.cpp
+++ b/src/BBOP/Graphics/EBO.cpp
@@ -8,6 +8,17 @@ EBO::EBO(GLuint* indices, GLsizeiptr size)
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, indices, GL_STATIC_DRAW);
 }
 
+EBO::EBO()
+{
+  glGenBuffers(1, &ID);
+}
+
+void EBO::init(GLuint* indices, GLsizeiptr size)
+{
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ID);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, indices, GL_STATIC_DRAW);
+}
+
 // Binds the EBO
 void EBO::Bind() const
 {

--- a/src/BBOP/Graphics/VBO.cpp
+++ b/src/BBOP/Graphics/VBO.cpp
@@ -8,6 +8,17 @@ VBO::VBO(GLfloat* vertices, GLsizeiptr size, GLenum typeVBO)
 	glBufferData(GL_ARRAY_BUFFER, size, vertices, typeVBO);
 }
 
+VBO::VBO()
+{
+  glGenBuffers(1, &ID);
+}
+
+void VBO::init(GLfloat* vertices, GLsizeiptr size, GLenum typeVBO)
+{
+  glBindBuffer(GL_ARRAY_BUFFER, ID);
+	glBufferData(GL_ARRAY_BUFFER, size, vertices, typeVBO);
+}
+
 // Binds the VBO
 void VBO::Bind() const
 {

--- a/src/BBOP/Graphics/shapeClass.cpp
+++ b/src/BBOP/Graphics/shapeClass.cpp
@@ -1,7 +1,5 @@
 #include "../../../include/BBOP/Graphics/shapeClass.h"
 
-#include <iostream>
-
 using namespace std;
 
 Shape::Shape(GLfloat* vertices, GLsizeiptr verticesSize, GLuint* indices, GLsizeiptr indicesSize)
@@ -16,6 +14,25 @@ Shape::Shape(GLfloat* vertices, GLsizeiptr verticesSize, GLuint* indices, GLsize
     rotation(0.0f),
     alpha(1.0f)
 {}
+
+Shape::Shape()
+  : shapeVBO(),
+    shapeEBO(),
+    pos(0.0f, 0.0f),
+    size(0.0f, 0.0f),
+    origin(0.0f, 0.0f),
+    RGB(255,255,255),
+    shapeCollisionBox(pos, origin, size),
+    autoUpdateCollision(true),
+    rotation(0.0f),
+    alpha(1.0f)
+{}
+
+void Shape::init(GLfloat* vertices, GLsizeiptr verticesSize, GLuint* indices, GLsizeiptr indicesSize)
+{
+  shapeVBO.init(vertices, verticesSize, GL_DYNAMIC_DRAW);
+  shapeEBO.init(indices, indicesSize);
+}
 
 void Shape::setSize(Vector2f nSize)
 {
@@ -213,12 +230,13 @@ void RectangleShape::updateVBOAlpha()
 }
 
 ConvexShape::ConvexShape(int nnPoint, Vector2f* nlistPoint)
-  : vertices(new GLfloat[nnPoint*6]),
+  : Shape(),
+    vertices(new GLfloat[nnPoint*6]),
     indices(new GLuint[(nnPoint-1)*3]),
-    Shape(vertices, sizeof(GLfloat)*6*nnPoint, indices, sizeof(GLuint)*3*(nnPoint-1)),
     nPoint(nnPoint),
     listPoint(new Vector2f[nnPoint])
 {
+  init(vertices, sizeof(GLfloat)*6*nnPoint, indices, sizeof(GLuint)*3*(nnPoint-1));
   for(int i = 0; i < nnPoint; i++)
     listPoint[i] = nlistPoint[i];
   size.x = 1.0f; size.y=1.0f;


### PR DESCRIPTION
Patch sur les formes convex qui produisait des erreur de segmentation aléatoire. creation d'n constructeur par deéfault dans Shape,VBO et EBO pour modifier l'ordre d'initialisation dans le contructeur de convex shape. (Ca enlève aussi les warn !!)